### PR TITLE
Add EDA_ANGLE patch for EDA_SHAPE::SetArcAngleAndEnd

### DIFF
--- a/pcbnewTransition/transition.py
+++ b/pcbnewTransition/transition.py
@@ -84,6 +84,12 @@ def patchRotate(item):
             newSetHatchOrientation = lambda self, angle: originalSetHatchOrientation(self, angle.AsTenthsOfADegree())
             setattr(newSetHatchOrientation, "patched", True)
             item.SetHatchOrientation = newSetHatchOrientation
+    if hasattr(item, "SetArcAngleAndEnd"):
+        originalSetArcAngleAndEnd = item.SetArcAngleAndEnd
+        if not getattr(originalSetArcAngleAndEnd, "patched", False):
+            newSetArcAngleAndEnd = lambda self, angle, check_neg: originalSetArcAngleAndEnd(self, angle.AsTenthsOfADegree(), check_neg)
+            setattr(newSetArcAngleAndEnd, "patched", True)
+            item.SetArcAngleAndEnd = newSetArcAngleAndEnd
 
 def pathGetItemDescription(item):
     if hasattr(item, "GetSelectMenuText") and not hasattr(item, "GetItemDescription"):


### PR DESCRIPTION
Used by kikit.stencil.addBottomCounterpart

At least on my system this is needed by KiKit using KiCad 6.
BTW: I don't see the 0.3.4 tag on GitHub.